### PR TITLE
Fix payload framing for TCP transmission

### DIFF
--- a/src/meshcore_proxy/proxy.py
+++ b/src/meshcore_proxy/proxy.py
@@ -200,9 +200,9 @@ class MeshCoreProxy:
                     print(f"{arrow} {type_name} [{len(payload)} bytes]: {payload.hex()}", flush=True)
 
     def _frame_payload(self, payload: bytes) -> bytes:
-        """Frame a payload for TCP transmission (0x3c + 2-byte size + payload)."""
+        """Frame a payload for TCP transmission (0x3e + 2-byte size + payload)."""
         size = len(payload)
-        return b"\x3c" + size.to_bytes(2, byteorder="little") + payload
+        return b"\x3e" + size.to_bytes(2, byteorder="little") + payload
 
     async def _handle_radio_rx(self, payload: bytes) -> None:
         """Handle data received from the radio - forward to all TCP clients."""


### PR DESCRIPTION
I found an issue with meshcore-packet-capture when used with Home Assistant. After comparing two PCAP captures, I identified a framing mismatch in the TCP proxy.

**Problem**

The _frame_payload method in proxy.py uses 0x3C (<) as the frame direction byte when forwarding radio responses to TCP clients.

According to the MeshCore TCP framing protocol:
	•	0x3C (<) → client → server
	•	0x3E (>) → server → client

However, the proxy forwards server responses using 0x3C.

The official meshcore_py TCP client (tcp_cx.py) looks for 0x3E as the start-of-frame in handle_rx(). Any frame not starting with 0x3E is silently discarded.

As a result:
	•	All proxy-forwarded responses are dropped.
	•	The client eventually times out and disconnects.