### PR TITLE
Add a homeassistant addon

### DIFF
--- a/homeassistant-addons/meshcore-proxy-ha/Dockerfile
+++ b/homeassistant-addons/meshcore-proxy-ha/Dockerfile
@@ -1,0 +1,22 @@
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
+ENV LANG=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apk add --no-cache \
+        python3 \
+        py3-pip \
+        bluez \
+        bluez-deprecated \
+    && python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/venv/bin/pip install --no-cache-dir meshcore-proxy
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY run.sh /run.sh
+RUN chmod a+x /run.sh
+
+CMD [ "/run.sh" ]

--- a/homeassistant-addons/meshcore-proxy-ha/config.yaml
+++ b/homeassistant-addons/meshcore-proxy-ha/config.yaml
@@ -1,0 +1,34 @@
+name: MeshCore Proxy
+version: "0.1.0"
+slug: meshcore_proxy
+description: TCP bridge for a locally-connected MeshCore companion radio (USB serial or BLE).
+url: https://github.com/rgregg/meshcore-proxy
+arch:
+  - aarch64
+  - amd64
+init: false
+startup: services
+boot: auto
+host_network: false
+uart: true
+usb: true
+ports:
+  "5000/tcp": 5000
+ports_description:
+  "5000/tcp": MeshCore TCP proxy
+options:
+  connection_type: serial
+  serial_device: /dev/ttyUSB0
+  baud: 115200
+  ble_address: ""
+  ble_pin: "123456"
+  tcp_port: 5000
+  log_level: info
+schema:
+  connection_type: list(serial|ble)
+  serial_device: device(subsystem=tty)?
+  baud: int(9600,921600)
+  ble_address: str?
+  ble_pin: str?
+  tcp_port: port
+  log_level: list(debug|info|events|events_verbose|json)

--- a/homeassistant-addons/meshcore-proxy-ha/run.sh
+++ b/homeassistant-addons/meshcore-proxy-ha/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/with-contenv bashio
+set -e
+
+CONNECTION_TYPE="$(bashio::config 'connection_type')"
+TCP_PORT="$(bashio::config 'tcp_port')"
+LOG_LEVEL="$(bashio::config 'log_level')"
+
+ARGS=(--host 0.0.0.0 --port "${TCP_PORT}")
+
+case "${CONNECTION_TYPE}" in
+    serial)
+        if ! bashio::config.has_value 'serial_device'; then
+            bashio::exit.nok "connection_type is 'serial' but no serial_device was selected. Open the add-on Configuration tab and pick a device."
+        fi
+        SERIAL_DEVICE="$(bashio::config 'serial_device')"
+        BAUD="$(bashio::config 'baud')"
+        ARGS+=(--serial "${SERIAL_DEVICE}" --baud "${BAUD}")
+        bashio::log.info "Proxying serial device: ${SERIAL_DEVICE} @ ${BAUD} baud"
+        ;;
+    ble)
+        if ! bashio::config.has_value 'ble_address'; then
+            bashio::exit.nok "connection_type is 'ble' but no ble_address was provided."
+        fi
+        BLE_ADDRESS="$(bashio::config 'ble_address')"
+        ARGS+=(--ble "${BLE_ADDRESS}")
+        if bashio::config.has_value 'ble_pin'; then
+            ARGS+=(--ble-pin "$(bashio::config 'ble_pin')")
+        fi
+        bashio::log.info "Proxying BLE device: ${BLE_ADDRESS}"
+        ;;
+    *)
+        bashio::exit.nok "Unknown connection_type: ${CONNECTION_TYPE}"
+        ;;
+esac
+
+case "${LOG_LEVEL}" in
+    debug)          ARGS+=(--debug) ;;
+    events)         ARGS+=(--log-events) ;;
+    events_verbose) ARGS+=(--log-events-verbose) ;;
+    json)           ARGS+=(--json) ;;
+    info)           : ;;
+esac
+
+# Report where the proxy is reachable from. The add-on's TCP port is mapped
+# to the host at the port configured above, so clients on the LAN connect to
+# the Home Assistant host IP on that port.
+HOST_IP="$(bashio::network.ipv4_address 2>/dev/null || true)"
+if [ -z "${HOST_IP}" ] || [ "${HOST_IP}" = "null" ]; then
+    HOST_IP="<home-assistant-host-ip>"
+else
+    HOST_IP="${HOST_IP%/*}"
+fi
+
+bashio::log.info "----------------------------------------------------------"
+bashio::log.info " MeshCore Proxy is starting"
+bashio::log.info " Reachable at: tcp://${HOST_IP}:${TCP_PORT}"
+bashio::log.info " (from any device on the same network as Home Assistant)"
+bashio::log.info "----------------------------------------------------------"
+
+exec meshcore-proxy "${ARGS[@]}"


### PR DESCRIPTION
Vibe coded home assistant add on.

Came from discussion on https://github.com/meshcore-dev/meshcore-ha/issues/195

Feel free to close if this is not desirable.

Logs from running

```
INFO:meshcore:Serial Connection started
INFO:meshcore_proxy.proxy:Connected to radio: /dev/serial/by-id/usb-Espressif_Systems_heltec_wifi_lora_32_v4__16_MB_FLASH__2_MB_PSRAM__xxxx
INFO:meshcore_proxy.proxy:Client connected: ('172.30.32.1', 57146)
INFO:meshcore_proxy.proxy:Client disconnected: ('172.30.32.1', 57146)
INFO:meshcore_proxy.proxy:Client connected: ('172.30.32.1', 50236)
INFO:meshcore_proxy.proxy:Client disconnected: ('172.30.32.1', 50236)
```