### PR TITLE
Support upstream TCP companion connections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## Project Overview
 
-This project builds a **TCP proxy** that enables a locally-connected MeshCore companion radio (via USB Serial or BLE) to be accessed by remote clients over a TCP network connection.
+This project builds a **TCP proxy** that enables a MeshCore companion radio connected via USB Serial, BLE, or an upstream TCP companion endpoint to be accessed by remote clients over a TCP network connection.
 
 ### Goals
 
-- Connect to a MeshCore companion radio via USB Serial or Bluetooth Low Energy (BLE)
+- Connect to a MeshCore companion radio via USB Serial, Bluetooth Low Energy (BLE), or an upstream TCP companion endpoint
 - Expose that radio to remote clients via TCP
 - **Decode and log events** - Display human-readable logs of all events sent to/received from the radio
 - Maintain compatibility with existing MeshCore clients:
@@ -42,7 +42,7 @@ Python is the correct choice for this project because:
 ## Architecture
 
 ```
-┌─────────────────┐     USB/BLE      ┌──────────────────┐
+┌─────────────────┐   USB/BLE/TCP    ┌──────────────────┐
 │  MeshCore Radio │ ◄──────────────► │  meshcore-proxy  │
 │  (Companion FW) │                  │                  │
 └─────────────────┘                  │  ┌────────────┐  │
@@ -79,16 +79,17 @@ Key reference files in the submodule:
 
 ### Connection Types
 
-Support two local connection methods:
+Support three radio connection methods:
 
 1. **USB Serial** - `/dev/ttyUSB0` or `/dev/ttyACM0` at 115200 baud
 2. **BLE** - Connect via Bluetooth MAC address (default PIN: `123456`)
+3. **Upstream TCP** - Connect to a MeshCore companion endpoint via `HOST[:PORT]` (default port: `5000`)
 
 ### Configuration
 
 The proxy should accept configuration for:
-- Local connection type (serial or ble)
-- Serial port path or BLE MAC address
+- Local connection type (`serial`, `ble`, or `tcp`)
+- Serial port path, BLE MAC address, or upstream TCP host/port
 - TCP server bind address and port
 - Event logging verbosity (off, summary, verbose/decoded)
 - Optional: logging level, reconnection settings
@@ -139,6 +140,9 @@ meshcore-cli --serial /dev/ttyUSB0
 # Connect via BLE
 meshcore-cli --ble 12:34:56:78:90:AB
 
+# Proxy an upstream TCP companion endpoint
+meshcore-proxy --tcp 192.168.1.103:5000
+
 # Connect via TCP (what our proxy exposes)
 meshcore-cli --tcp 192.168.1.100:5000
 ```
@@ -179,11 +183,15 @@ docker run --device=/dev/ttyUSB0 -p 5000:5000 meshcore-proxy --serial /dev/ttyUS
 
 # Run with BLE (requires host network and bluetooth access)
 docker run --net=host --privileged meshcore-proxy --ble 12:34:56:78:90:AB
+
+# Run with upstream TCP companion mode
+docker run -p 5000:5000 meshcore-proxy --tcp 192.168.1.103:5000
 ```
 
 **Docker considerations:**
 - USB serial requires `--device` flag to pass through the serial port
 - BLE requires `--net=host` and `--privileged` (or specific capabilities) for Bluetooth access
+- Upstream TCP mode only needs network access to the companion endpoint
 - Consider providing a `docker-compose.yml` for easier configuration
 
 ### PyPI Publishing

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ meshcore-proxy --ble MeshCore-07BA3987
 ```bash
 # Keep one exclusive session to the radio's WiFi companion endpoint
 meshcore-proxy --tcp 192.168.1.103:5000
+
+# IPv6 with an explicit port uses brackets
+meshcore-proxy --tcp [2001:db8::1]:5000
 ```
 
 ### Connect a Client
@@ -108,7 +111,8 @@ Connection (one required):
   --serial PORT     Serial port path (e.g., /dev/ttyUSB0)
   --ble ADDR        BLE device address (see platform notes below)
   --tcp HOST[:PORT]
-                    Upstream MeshCore TCP endpoint (e.g., 192.168.1.103:5000)
+                    Upstream MeshCore TCP endpoint (e.g., 192.168.1.103:5000
+                    or [2001:db8::1]:5000 for IPv6)
 
 Server options:
   --host ADDR       TCP bind address (default: 0.0.0.0)
@@ -330,6 +334,13 @@ Use a different port:
 ```bash
 meshcore-proxy --serial /dev/ttyUSB0 --port 5001
 ```
+
+### IPv6 upstream TCP endpoint
+
+When using `--tcp` with an IPv6 literal:
+
+- Use the bare address when using the default upstream port `5000`, for example `--tcp 2001:db8::1`
+- Use brackets when specifying an explicit port, for example `--tcp [2001:db8::1]:5001`
 
 ### BLE connection fails
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # MeshCore Proxy
 
-A TCP proxy that enables remote access to a locally-connected MeshCore companion radio.
+A TCP proxy that enables remote access to a locally-connected or upstream TCP MeshCore companion radio.
 
 ## Overview
 
-MeshCore Proxy connects to a MeshCore radio via USB Serial or Bluetooth LE and exposes it over TCP, allowing remote clients to interact with the radio as if it were directly connected.
+MeshCore Proxy connects to a MeshCore radio via USB Serial, Bluetooth LE, or an upstream TCP companion endpoint and exposes it over TCP, allowing remote clients to interact with the radio as if it were directly connected.
 
 ```
-┌─────────────────┐     USB/BLE      ┌──────────────────┐
+┌─────────────────┐  USB/BLE/TCP up  ┌──────────────────┐
 │  MeshCore Radio │ ◄──────────────► │  meshcore-proxy  │
 │  (Companion FW) │                  │                  │
 └─────────────────┘                  │  TCP :5000       │
@@ -84,6 +84,13 @@ meshcore-proxy --ble 7921236E-065C-0C7B-C04D-7F60E849DC47
 meshcore-proxy --ble MeshCore-07BA3987
 ```
 
+### Upstream TCP Companion
+
+```bash
+# Keep one exclusive session to the radio's WiFi companion endpoint
+meshcore-proxy --tcp 192.168.1.103:5000
+```
+
 ### Connect a Client
 
 Once the proxy is running, connect clients to `localhost:5000`:
@@ -100,6 +107,8 @@ meshcore-proxy [OPTIONS]
 Connection (one required):
   --serial PORT     Serial port path (e.g., /dev/ttyUSB0)
   --ble ADDR        BLE device address (see platform notes below)
+  --tcp HOST[:PORT]
+                    Upstream MeshCore TCP endpoint (e.g., 192.168.1.103:5000)
 
 Server options:
   --host ADDR       TCP bind address (default: 0.0.0.0)
@@ -210,6 +219,16 @@ docker run -d \
   --ble 12:34:56:78:90:AB
 ```
 
+### Upstream TCP Companion
+
+```bash
+docker run -d \
+  --name meshcore-proxy \
+  -p 5000:5000 \
+  -e RADIO_TCP=192.168.1.103:5000 \
+  ghcr.io/rgregg/meshcore-proxy:latest
+```
+
 ### Docker Compose
 
 ```bash
@@ -218,6 +237,9 @@ docker compose --profile serial up -d
 
 # BLE (set address in environment)
 BLE_ADDRESS=12:34:56:78:90:AB docker compose --profile ble up -d
+
+# Upstream TCP companion
+RADIO_TCP=192.168.1.103:5000 docker compose --profile tcp up -d
 ```
 
 ### View Logs
@@ -249,6 +271,20 @@ Configure the [MeshCore Home Assistant integration](https://github.com/awolden/m
 
 - **Host:** IP address of machine running the proxy
 - **Port:** 5000 (or your custom port)
+
+### WiFi Companion Multiplexing
+
+If your radio's WiFi companion endpoint only supports one active TCP client,
+have `meshcore-proxy` hold that connection open and point all apps at the proxy:
+
+```text
+Home Assistant ---\
+MeshCore app ------> meshcore-proxy ----> radio-wifi:5000
+meshcore-cli ------/
+```
+
+This makes the proxy the single upstream TCP owner while still allowing
+multiple downstream clients to share the radio.
 
 ### Running as a System Service (Linux)
 
@@ -311,7 +347,7 @@ meshcore-proxy --serial /dev/ttyUSB0 --port 5001
 ## Requirements
 
 - Python 3.10+
-- MeshCore companion radio with USB or BLE firmware
+- MeshCore companion radio with USB, BLE, or TCP companion access
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,12 @@
 # Usage:
 #   USB Serial: docker compose --profile serial up
 #   BLE:        docker compose --profile ble up
+#   TCP:        docker compose --profile tcp up
 #
 # Environment variables (can be set in .env file or shell):
 #   SERIAL_PORT        - Serial port path (default: /dev/ttyUSB0)
 #   BLE_ADDRESS        - BLE device MAC address
+#   RADIO_TCP          - Upstream MeshCore TCP endpoint (HOST[:PORT])
 #   TCP_PORT           - TCP server port (default: 5000)
 #   BLE_PIN            - BLE pairing PIN (default: 123456)
 #   LOG_LEVEL          - Log verbosity: off, error, warning, info, debug, verbose (default: info)
@@ -41,6 +43,20 @@ services:
     environment:
       - BLE_ADDRESS=${BLE_ADDRESS:-}
       - BLE_PIN=${BLE_PIN:-123456}
+      - TCP_PORT=${TCP_PORT:-5000}
+      - VIRTUALIZE_CHANNELS=${VIRTUALIZE_CHANNELS:-}
+      - LOG_LEVEL=${LOG_LEVEL:-}
+      - LOG_JSON=${LOG_JSON:-}
+    restart: unless-stopped
+
+  # Upstream TCP connection profile
+  meshcore-proxy-tcp:
+    image: ghcr.io/rgregg/meshcore-proxy:latest
+    profiles: ["tcp"]
+    ports:
+      - "${TCP_PORT:-5000}:${TCP_PORT:-5000}"
+    environment:
+      - RADIO_TCP=${RADIO_TCP:-}
       - TCP_PORT=${TCP_PORT:-5000}
       - VIRTUALIZE_CHANNELS=${VIRTUALIZE_CHANNELS:-}
       - LOG_LEVEL=${LOG_LEVEL:-}

--- a/src/meshcore_proxy/cli.py
+++ b/src/meshcore_proxy/cli.py
@@ -11,6 +11,29 @@ import sys
 from meshcore_proxy.proxy import EventLogLevel, MeshCoreProxy
 
 
+def _parse_tcp_endpoint(value: str) -> tuple[str, int]:
+    """Parse an upstream TCP endpoint in HOST or HOST:PORT form."""
+    value = value.strip()
+    if not value:
+        raise ValueError("TCP endpoint cannot be empty")
+
+    if ":" not in value:
+        return value, 5000
+
+    host, port_str = value.rsplit(":", 1)
+    if not host:
+        raise ValueError("TCP endpoint host cannot be empty")
+    if not port_str:
+        raise ValueError("TCP endpoint port cannot be empty")
+
+    try:
+        port = int(port_str)
+    except ValueError as exc:
+        raise ValueError(f"Invalid TCP port: {port_str}") from exc
+
+    return host, port
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="TCP proxy for MeshCore companion radios",
@@ -23,6 +46,9 @@ Examples:
   # Connect via BLE
   meshcore-proxy --ble 12:34:56:78:90:AB
 
+  # Connect via upstream TCP
+  meshcore-proxy --tcp 192.168.1.103:5000
+
   # With event logging
   meshcore-proxy --serial /dev/ttyUSB0 --log-level debug
 
@@ -34,7 +60,13 @@ Examples:
     # Connection type (mutually exclusive)
     # Allow env vars so docker-compose can configure without modifying command
     conn_group = parser.add_mutually_exclusive_group(
-        required=not (os.environ.get("SERIAL_PORT") or os.environ.get("BLE_ADDRESS")),
+        required=not (
+            os.environ.get("SERIAL_PORT")
+            or os.environ.get("BLE_ADDRESS")
+            or os.environ.get("RADIO_TCP")
+            or os.environ.get("RADIO_TCP_ADDRESS")
+            or os.environ.get("RADIO_TCP_HOST")
+        ),
     )
     conn_group.add_argument(
         "--serial",
@@ -47,6 +79,19 @@ Examples:
         metavar="MAC",
         default=os.environ.get("BLE_ADDRESS"),
         help="BLE device MAC address (e.g., 12:34:56:78:90:AB) [env: BLE_ADDRESS]",
+    )
+    conn_group.add_argument(
+        "--tcp",
+        metavar="HOST[:PORT]",
+        default=(
+            os.environ.get("RADIO_TCP")
+            or os.environ.get("RADIO_TCP_ADDRESS")
+            or os.environ.get("RADIO_TCP_HOST")
+        ),
+        help=(
+            "Upstream MeshCore TCP endpoint (e.g., 192.168.1.103 or "
+            "192.168.1.103:5000) [env: RADIO_TCP or RADIO_TCP_ADDRESS]"
+        ),
     )
 
     # TCP server options
@@ -103,7 +148,21 @@ Examples:
         help="Virtualize channel slots for multi-client isolation [env: VIRTUALIZE_CHANNELS]",
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    args.radio_tcp_host = None
+    args.radio_tcp_port = None
+    if args.tcp:
+        tcp_value = args.tcp
+        # Preserve compatibility with older HOST/PORT env vars if only host is set.
+        if ":" not in tcp_value and os.environ.get("RADIO_TCP_PORT"):
+            tcp_value = f"{tcp_value}:{os.environ['RADIO_TCP_PORT']}"
+        try:
+            args.radio_tcp_host, args.radio_tcp_port = _parse_tcp_endpoint(tcp_value)
+        except ValueError as exc:
+            parser.error(str(exc))
+
+    return args
 
 
 async def run_with_shutdown(proxy: MeshCoreProxy) -> None:
@@ -183,6 +242,8 @@ def main() -> int:
     proxy = MeshCoreProxy(
         serial_port=args.serial,
         ble_address=args.ble,
+        radio_tcp_host=args.radio_tcp_host,
+        radio_tcp_port=args.radio_tcp_port,
         baud_rate=args.baud,
         ble_pin=args.ble_pin,
         tcp_host=args.host,

--- a/src/meshcore_proxy/cli.py
+++ b/src/meshcore_proxy/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import asyncio
 import functools
+import ipaddress
 import logging
 import os
 import signal
@@ -17,8 +18,41 @@ def _parse_tcp_endpoint(value: str) -> tuple[str, int]:
     if not value:
         raise ValueError("TCP endpoint cannot be empty")
 
+    if value.startswith("["):
+        host, separator, port_str = value[1:].partition("]")
+        if not separator:
+            raise ValueError("Invalid bracketed IPv6 endpoint; missing closing ']'")
+        if not host:
+            raise ValueError("TCP endpoint host cannot be empty")
+        try:
+            ipaddress.IPv6Address(host)
+        except ValueError as exc:
+            raise ValueError(f"Invalid IPv6 address: {host}") from exc
+        if not port_str:
+            return host, 5000
+        if not port_str.startswith(":"):
+            raise ValueError("Invalid bracketed IPv6 endpoint; expected [HOST]:PORT")
+        port_str = port_str[1:]
+        if not port_str:
+            raise ValueError("TCP endpoint port cannot be empty")
+        try:
+            port = int(port_str)
+        except ValueError as exc:
+            raise ValueError(f"Invalid TCP port: {port_str}") from exc
+        return host, port
+
+    try:
+        ipaddress.IPv6Address(value)
+    except ValueError:
+        pass
+    else:
+        return value, 5000
+
     if ":" not in value:
         return value, 5000
+
+    if value.count(":") > 1:
+        raise ValueError("IPv6 endpoints with ports must use bracket syntax: [HOST]:PORT")
 
     host, port_str = value.rsplit(":", 1)
     if not host:
@@ -48,6 +82,9 @@ Examples:
 
   # Connect via upstream TCP
   meshcore-proxy --tcp 192.168.1.103:5000
+
+  # Connect via upstream TCP over IPv6
+  meshcore-proxy --tcp [2001:db8::1]:5000
 
   # With event logging
   meshcore-proxy --serial /dev/ttyUSB0 --log-level debug
@@ -90,7 +127,8 @@ Examples:
         ),
         help=(
             "Upstream MeshCore TCP endpoint (e.g., 192.168.1.103 or "
-            "192.168.1.103:5000) [env: RADIO_TCP or RADIO_TCP_ADDRESS]"
+            "192.168.1.103:5000, or [2001:db8::1]:5000 for IPv6) "
+            "[env: RADIO_TCP or RADIO_TCP_ADDRESS]"
         ),
     )
 

--- a/src/meshcore_proxy/proxy.py
+++ b/src/meshcore_proxy/proxy.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 try:
     from meshcore.serial_cx import SerialConnection
     from meshcore.ble_cx import BLEConnection
+    from meshcore.tcp_cx import TCPConnection
     from meshcore.packets import PacketType
 except ImportError:
     # Fall back to submodule path for development
@@ -27,6 +28,7 @@ except ImportError:
     sys.path.insert(0, os.path.abspath(submodule_path))
     from meshcore.serial_cx import SerialConnection
     from meshcore.ble_cx import BLEConnection
+    from meshcore.tcp_cx import TCPConnection
     from meshcore.packets import PacketType
 
 
@@ -119,6 +121,8 @@ class MeshCoreProxy:
         self,
         serial_port: Optional[str] = None,
         ble_address: Optional[str] = None,
+        radio_tcp_host: Optional[str] = None,
+        radio_tcp_port: int = 5000,
         baud_rate: int = 115200,
         ble_pin: str = "123456",
         tcp_host: str = "0.0.0.0",
@@ -129,6 +133,8 @@ class MeshCoreProxy:
     ):
         self.serial_port = serial_port
         self.ble_address = ble_address
+        self.radio_tcp_host = radio_tcp_host
+        self.radio_tcp_port = radio_tcp_port
         self.baud_rate = baud_rate
         self.ble_pin = ble_pin
         self.tcp_host = tcp_host
@@ -141,7 +147,7 @@ class MeshCoreProxy:
             self._channel_allocator = ChannelSlotAllocator()
             logger.info("Channel slot virtualization enabled")
 
-        self._radio_connection: Optional[SerialConnection | BLEConnection] = None
+        self._radio_connection: Optional[SerialConnection | BLEConnection | TCPConnection] = None
         self._tcp_server: Optional[asyncio.Server] = None
         self._clients: dict[tuple, TCPClient] = {}
         self._is_ble = False
@@ -158,6 +164,16 @@ class MeshCoreProxy:
                 logger.warning("Radio disconnected: %s", reason)
             else:
                 logger.warning("Radio disconnected.")
+
+    def _get_radio_target(self) -> tuple[str, Optional[str]]:
+        """Describe the configured upstream radio transport."""
+        if self.serial_port:
+            return "serial", self.serial_port
+        if self.ble_address:
+            return "BLE", self.ble_address
+        if self.radio_tcp_host:
+            return "tcp", f"{self.radio_tcp_host}:{self.radio_tcp_port}"
+        return "unknown", None
 
     def _log_event(
         self,
@@ -414,6 +430,17 @@ class MeshCoreProxy:
                 pin=self.ble_pin if self.ble_pin else None,
             )
             self._is_ble = True
+        elif self.radio_tcp_host:
+            logger.info(
+                "Connecting to radio via TCP: %s:%s",
+                self.radio_tcp_host,
+                self.radio_tcp_port,
+            )
+            self._radio_connection = TCPConnection(
+                self.radio_tcp_host,
+                self.radio_tcp_port,
+            )
+            self._is_ble = False
         else:
             raise ValueError("No connection method specified")
 
@@ -451,8 +478,7 @@ class MeshCoreProxy:
     async def run(self) -> None:
         """Run the proxy."""
         self._is_running = True
-        conn_type = "serial" if self.serial_port else "BLE"
-        conn_target = self.serial_port or self.ble_address
+        conn_type, conn_target = self._get_radio_target()
         logger.info(f"Starting MeshCore Proxy ({conn_type}: {conn_target})...")
 
         await self._start_tcp_server()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,11 +3,12 @@
 import asyncio
 import os
 import signal
+import sys
 from unittest.mock import patch
 
 import pytest
 
-from meshcore_proxy.cli import run_with_shutdown
+from meshcore_proxy.cli import parse_args, run_with_shutdown
 from meshcore_proxy.proxy import EventLogLevel, MeshCoreProxy
 
 # Test timing constants
@@ -42,6 +43,64 @@ class MockRadio:
 
     def set_reader(self, reader):
         self.on_receive = reader.handle_rx
+
+
+def test_parse_args_accepts_tcp_endpoint(monkeypatch):
+    """Test that upstream TCP endpoint options are parsed correctly."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meshcore-proxy",
+            "--tcp",
+            "192.168.1.103:5000",
+        ],
+    )
+
+    args = parse_args()
+
+    assert args.radio_tcp_host == "192.168.1.103"
+    assert args.radio_tcp_port == 5000
+    assert args.serial is None
+    assert args.ble is None
+
+
+def test_parse_args_accepts_tcp_env(monkeypatch):
+    """Test that upstream TCP environment variables satisfy connection selection."""
+    monkeypatch.setenv("RADIO_TCP", "192.168.1.103:5001")
+    monkeypatch.setattr(sys, "argv", ["meshcore-proxy"])
+
+    args = parse_args()
+
+    assert args.radio_tcp_host == "192.168.1.103"
+    assert args.radio_tcp_port == 5001
+
+
+def test_parse_args_accepts_tcp_host_without_port(monkeypatch):
+    """Test that --tcp defaults to port 5000 when no port is provided."""
+    monkeypatch.setattr(sys, "argv", ["meshcore-proxy", "--tcp", "192.168.1.103"])
+
+    args = parse_args()
+
+    assert args.radio_tcp_host == "192.168.1.103"
+    assert args.radio_tcp_port == 5000
+
+
+def test_parse_args_requires_connection_mode(monkeypatch):
+    """Test that one upstream connection mode is required."""
+    for var in (
+        "SERIAL_PORT",
+        "BLE_ADDRESS",
+        "RADIO_TCP",
+        "RADIO_TCP_ADDRESS",
+        "RADIO_TCP_HOST",
+        "RADIO_TCP_PORT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(sys, "argv", ["meshcore-proxy"])
+
+    with pytest.raises(SystemExit):
+        parse_args()
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,6 +86,46 @@ def test_parse_args_accepts_tcp_host_without_port(monkeypatch):
     assert args.radio_tcp_port == 5000
 
 
+def test_parse_args_accepts_bracketed_ipv6_with_port(monkeypatch):
+    """Test that bracketed IPv6 endpoints parse correctly with a port."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["meshcore-proxy", "--tcp", "[2001:db8::1]:5001"],
+    )
+
+    args = parse_args()
+
+    assert args.radio_tcp_host == "2001:db8::1"
+    assert args.radio_tcp_port == 5001
+
+
+def test_parse_args_accepts_bare_ipv6_without_port(monkeypatch):
+    """Test that bare IPv6 endpoints default to port 5000."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["meshcore-proxy", "--tcp", "2001:db8::1"],
+    )
+
+    args = parse_args()
+
+    assert args.radio_tcp_host == "2001:db8::1"
+    assert args.radio_tcp_port == 5000
+
+
+def test_parse_args_rejects_malformed_multi_colon_endpoint(monkeypatch):
+    """Test that malformed multi-colon endpoints are rejected."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["meshcore-proxy", "--tcp", "2001:db8::zzzz:5001"],
+    )
+
+    with pytest.raises(SystemExit):
+        parse_args()
+
+
 def test_parse_args_requires_connection_mode(monkeypatch):
     """Test that one upstream connection mode is required."""
     for var in (

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -69,6 +69,36 @@ async def test_initial_connection_failure_and_reconnect(mock_serial_connection):
 
 
 @pytest.mark.asyncio
+@patch("meshcore_proxy.proxy.TCPConnection")
+async def test_initial_tcp_connection_failure_and_reconnect(mock_tcp_connection):
+    """
+    Tests that the proxy attempts to reconnect if the initial TCP connection fails.
+    """
+    mock_radio = MockRadio(connect_fails=1)
+    mock_tcp_connection.return_value = mock_radio
+
+    proxy = MeshCoreProxy(
+        radio_tcp_host="192.168.1.103",
+        radio_tcp_port=5000,
+        event_log_level=EventLogLevel.OFF,
+        tcp_port=5004,
+    )
+
+    proxy_task = asyncio.create_task(proxy.run())
+    await asyncio.sleep(6)
+
+    assert proxy._radio_connected
+    assert mock_radio.connect_attempts == 2
+    mock_tcp_connection.assert_called_with("192.168.1.103", 5000)
+
+    proxy_task.cancel()
+    try:
+        await proxy_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
 @patch("meshcore_proxy.proxy.SerialConnection")
 async def test_disconnection_and_reconnection(mock_serial_connection):
     """
@@ -98,6 +128,29 @@ async def test_disconnection_and_reconnection(mock_serial_connection):
         await proxy_task
     except asyncio.CancelledError:
         pass
+
+
+@pytest.mark.asyncio
+@patch("meshcore_proxy.proxy.TCPConnection")
+async def test_connect_radio_uses_tcp_connection(mock_tcp_connection):
+    """
+    Tests that TCP upstream selection instantiates the meshcore TCP transport.
+    """
+    mock_radio = MockRadio(connect_fails=0)
+    mock_tcp_connection.return_value = mock_radio
+
+    proxy = MeshCoreProxy(
+        radio_tcp_host="192.168.1.103",
+        radio_tcp_port=5000,
+        event_log_level=EventLogLevel.OFF,
+    )
+
+    await proxy._connect_radio()
+
+    assert proxy._radio_connected
+    assert proxy._radio_connection is mock_radio
+    assert not proxy._is_ble
+    mock_tcp_connection.assert_called_once_with("192.168.1.103", 5000)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a `--tcp HOST[:PORT]` upstream transport so `meshcore-proxy` can connect to a MeshCore companion endpoint over TCP instead of only serial or BLE
- let the proxy hold one upstream TCP companion session open and fan it out to multiple downstream TCP clients
- document the new mode for CLI, Docker, and Compose usage, and add CLI parsing plus reconnection coverage for the TCP transport path

## Why
Some MeshCore WiFi companion endpoints only allow a single active TCP client. This change lets `meshcore-proxy` own that upstream connection and expose a stable local TCP endpoint for multiple consumers such as Home Assistant, the app, and CLI tools.

Serial and BLE behavior are unchanged.

## Validation
- `pytest tests/test_cli.py tests/test_proxy.py`
- Added coverage for TCP endpoint parsing and upstream TCP reconnection behavior