### PR TITLE
Add TCP support for remote MeshCore radio connection

### DIFF
--- a/src/meshcore_proxy/cli.py
+++ b/src/meshcore_proxy/cli.py
@@ -12,6 +12,7 @@ from meshcore_proxy.proxy import EventLogLevel, MeshCoreProxy
 
 
 def parse_args() -> argparse.Namespace:
+    import re
     parser = argparse.ArgumentParser(
         description="TCP proxy for MeshCore companion radios",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -23,10 +24,14 @@ Examples:
   # Connect via BLE
   meshcore-proxy --ble 12:34:56:78:90:AB
 
+  # Connect to a remote radio via TCP (default port 5000)
+  meshcore-proxy --tcp 192.168.1.50
+  meshcore-proxy --tcp 192.168.1.50:5100
+
   # With event logging
   meshcore-proxy --serial /dev/ttyUSB0 --log-level debug
 
-  # Specify TCP port
+  # Specify TCP server port for clients
   meshcore-proxy --serial /dev/ttyUSB0 --port 5000
         """,
     )
@@ -34,7 +39,7 @@ Examples:
     # Connection type (mutually exclusive)
     # Allow env vars so docker-compose can configure without modifying command
     conn_group = parser.add_mutually_exclusive_group(
-        required=not (os.environ.get("SERIAL_PORT") or os.environ.get("BLE_ADDRESS")),
+        required=not (os.environ.get("SERIAL_PORT") or os.environ.get("BLE_ADDRESS") or os.environ.get("TCP_RADIO")),
     )
     conn_group.add_argument(
         "--serial",
@@ -47,6 +52,12 @@ Examples:
         metavar="MAC",
         default=os.environ.get("BLE_ADDRESS"),
         help="BLE device MAC address (e.g., 12:34:56:78:90:AB) [env: BLE_ADDRESS]",
+    )
+    conn_group.add_argument(
+        "--tcp",
+        metavar="HOST[:PORT]",
+        default=os.environ.get("TCP_RADIO"),
+        help="Remote MeshCore radio via TCP (host[:port], default port 5000) [env: TCP_RADIO]",
     )
 
     # TCP server options
@@ -103,7 +114,24 @@ Examples:
         help="Virtualize channel slots for multi-client isolation [env: VIRTUALIZE_CHANNELS]",
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    # Parse --tcp (host[:port]) if present
+    args.tcp_host = None
+    args.tcp_port = None
+    if args.tcp:
+        # Accept formats: host, host:port, [IPv6], [IPv6]:port
+        m = re.match(r'^(\[.*\]|[a-zA-Z0-9_.-]+)(?::([0-9]+))?$', args.tcp)
+        if not m:
+            parser.error(f"Invalid --tcp host[:port] format: {args.tcp}")
+        host = m.group(1)
+        if host.startswith('[') and host.endswith(']'):
+            host = host[1:-1]
+        port = int(m.group(2)) if m.group(2) else 5000
+        args.tcp_host = host
+        args.tcp_port = port
+
+    return args
 
 
 async def run_with_shutdown(proxy: MeshCoreProxy) -> None:
@@ -185,6 +213,8 @@ def main() -> int:
         ble_address=args.ble,
         baud_rate=args.baud,
         ble_pin=args.ble_pin,
+        tcp_radio_host=args.tcp_host,
+        tcp_radio_port=args.tcp_port,
         tcp_host=args.host,
         tcp_port=args.port,
         event_log_level=event_log_level,

--- a/src/meshcore_proxy/proxy.py
+++ b/src/meshcore_proxy/proxy.py
@@ -121,6 +121,8 @@ class MeshCoreProxy:
         ble_address: Optional[str] = None,
         baud_rate: int = 115200,
         ble_pin: str = "123456",
+        tcp_radio_host: Optional[str] = None,   # new, remote radio
+        tcp_radio_port: Optional[int] = None,
         tcp_host: str = "0.0.0.0",
         tcp_port: int = 5000,
         event_log_level: EventLogLevel = EventLogLevel.OFF,
@@ -131,6 +133,8 @@ class MeshCoreProxy:
         self.ble_address = ble_address
         self.baud_rate = baud_rate
         self.ble_pin = ble_pin
+        self.tcp_radio_host = tcp_radio_host
+        self.tcp_radio_port = tcp_radio_port
         self.tcp_host = tcp_host
         self.tcp_port = tcp_port
         self.event_log_level = event_log_level
@@ -255,11 +259,8 @@ class MeshCoreProxy:
             packet_type = payload[0] if payload else 0
             self._log_event("TO_RADIO", packet_type, payload)
 
-            # BLE sends raw payload, Serial/TCP adds framing
-            if self._is_ble:
-                await self._radio_connection.send(payload)
-            else:
-                await self._radio_connection.send(payload)
+            # Each connection type handles its own framing internally
+            await self._radio_connection.send(payload)
         except Exception as e:
             logger.error(f"Failed to send to radio: {e}")
             await self._handle_radio_disconnect()
@@ -400,7 +401,36 @@ class MeshCoreProxy:
 
     async def _connect_radio(self) -> None:
         """Connect to the MeshCore radio."""
-        if self.serial_port:
+        if self.tcp_radio_host:
+            # Clean up previous MeshCore instance if reconnecting
+            if hasattr(self, "_meshcore") and self._meshcore:
+                self._meshcore.stop()
+                self._meshcore = None
+
+            from meshcore.meshcore import MeshCore
+            logger.info(f"Connecting to radio via TCP: {self.tcp_radio_host}:{self.tcp_radio_port}")
+            meshcore = await MeshCore.create_tcp(
+                self.tcp_radio_host,
+                self.tcp_radio_port or 5000,
+            )
+            if meshcore is None:
+                raise ConnectionError("Failed to connect to radio via TCP")
+            self._radio_connection = meshcore.connection_manager
+            self._meshcore = meshcore
+            self._is_ble = False
+
+            # Chain proxy disconnect handler with MeshCore's internal one.
+            # MeshCore.__init__ already registered
+            # ConnectionManager.handle_disconnect on the raw TCPConnection,
+            # so we wrap it to also notify the proxy.
+            raw_cx = meshcore.connection_manager.connection
+            orig = raw_cx._disconnect_callback
+            async def _on_tcp_disconnect(reason):
+                await self._handle_radio_disconnect(reason)
+                if orig:
+                    await orig(reason)
+            raw_cx.set_disconnect_callback(_on_tcp_disconnect)
+        elif self.serial_port:
             logger.info(f"Connecting to radio via serial: {self.serial_port}")
             self._radio_connection = SerialConnection(
                 self.serial_port,
@@ -427,13 +457,18 @@ class MeshCoreProxy:
 
         self._radio_connection.set_reader(ReaderAdapter(self._handle_radio_rx))
 
-        # Set disconnect callback - both SerialConnection and BLEConnection use set_disconnect_callback
-        self._radio_connection.set_disconnect_callback(self._handle_radio_disconnect)
+        # Set disconnect callback - SerialConnection and BLEConnection invoke it directly.
+        # For TCP mode, the callback was already chained into the raw TCPConnection above.
+        if not self.tcp_radio_host:
+            self._radio_connection.set_disconnect_callback(self._handle_radio_disconnect)
 
-        # Connect
-        result = await self._radio_connection.connect()
-        if result is None:
-            raise ConnectionError("Failed to connect to radio")
+        # Connect (skip if already open via meshcore.connect)
+        if self.tcp_radio_host:
+            result = True  # meshcore.create_tcp already performs connection
+        else:
+            result = await self._radio_connection.connect()
+            if result is None:
+                raise ConnectionError("Failed to connect to radio")
 
         logger.info(f"Connected to radio: {result}")
         self._radio_connected = True
@@ -451,8 +486,15 @@ class MeshCoreProxy:
     async def run(self) -> None:
         """Run the proxy."""
         self._is_running = True
-        conn_type = "serial" if self.serial_port else "BLE"
-        conn_target = self.serial_port or self.ble_address
+        if self.tcp_radio_host:
+            conn_type = "TCP"
+            conn_target = f"{self.tcp_radio_host}:{self.tcp_radio_port}"
+        elif self.serial_port:
+            conn_type = "serial"
+            conn_target = self.serial_port
+        else:
+            conn_type = "BLE"
+            conn_target = self.ble_address
         logger.info(f"Starting MeshCore Proxy ({conn_type}: {conn_target})...")
 
         await self._start_tcp_server()
@@ -521,5 +563,10 @@ class MeshCoreProxy:
         # Disconnect radio
         if self._radio_connection and self._radio_connected:
             await self._radio_connection.disconnect()
-        
+
+        # Clean up MeshCore instance (TCP mode)
+        if hasattr(self, "_meshcore") and self._meshcore:
+            self._meshcore.stop()
+            self._meshcore = None
+
         self._radio_connected = False


### PR DESCRIPTION
This pull request adds support for connecting to a remote MeshCore radio over TCP, in addition to the existing serial and BLE options. It introduces a new `--tcp` command-line argument (and corresponding environment variable), parses the host and port, and updates the proxy logic to establish a TCP connection to a remote radio if specified.

I know the change might seem silly because, if your node already supports TCP, why would you need a TCP proxy? But it’s not silly, since the node only supports one connection at a time, and this allows you to have multiple clients working with the same node simultaneously.

**New TCP radio connection support:**

* Added `--tcp` command-line argument (and `TCP_RADIO` environment variable) to specify a remote MeshCore radio to connect via TCP (`host[:port]`, default port 5000), including argument parsing and validation in `parse_args` (`src/meshcore_proxy/cli.py`).
* Updated the `MeshCoreProxy` class to accept and store `tcp_radio_host` and `tcp_radio_port` parameters, and to connect to the remote radio via TCP if these are set (`src/meshcore_proxy/proxy.py`).
* Modified the main entrypoint to pass the new TCP radio parameters from parsed arguments into the proxy (`src/meshcore_proxy/cli.py`).Add --tcp host[:port] CLI option for remote radio. Allows proxy to connect to a companion radio over TCP as a client, in addition to serial and BLE. Updates argument parsing, mutual exclusion, and MeshCoreProxy connection logic.

As you can see, feel free to change anything or let me know what you think.